### PR TITLE
Fix dark mode bug

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -52,7 +52,7 @@ const isPageBottom = computed(() => {
 
 				<button
 					:title="`Change to ${isDark ? 'light' : 'dark'} mode`"
-					@click="toggleDarkMode"
+					@click="toggleDarkMode()"
 				>
 					<icon-ri-sun-line v-if="isDark" />
 					<icon-ri-moon-line v-else />


### PR DESCRIPTION
Bug: When switching to dark mode, you cannot switch back out of dark mode

Potentially because of function scoping, when binding this function to the button event handler it's caching the method that toggles back to `auto`, so you can't switch back to auto theme mode once switching to dark mode. The inline binding seems to evaluate dynamically so as to not have the same scoping/caching issue

EDIT:
Actually pretty sure just figured it out. The reason [in their demo](https://github.com/vueuse/vueuse/blob/main/packages/shared/useToggle/demo.vue#L10) they use an inline expression is probably because if you bind to the method, vue will pas through the pointer click event to the toggle method. However, the toggle method is designed to set its new value to the first argument set if one is passed, which in this case is that pointer event, and thus evaluates as truthy. Going to open a pull request with them adding some documentation since this should be quite a common use case.

<details><summary>Bound method function `arguments`...</summary>

<img width="633" alt="Screen Shot 2022-09-30 at 1 49 51 PM" src="https://user-images.githubusercontent.com/2652762/193328147-79d7e5f5-75c5-4deb-96f0-9429f2d628b2.png">

</details>

<details><summary>Dynamic expression function `arguments`...</summary>

<img width="635" alt="image" src="https://user-images.githubusercontent.com/2652762/193328546-d89565e2-96ac-4b35-81a7-c5e2c98f0fe7.png">

</details>