### PR TITLE
Update esbuild-kit/tsx to privatenumber/tsx

### DIFF
--- a/src/data/github-stars.json
+++ b/src/data/github-stars.json
@@ -1,7 +1,7 @@
 {
 	"repositories": {
 		"Nutlope/aicommits": 6541,
-		"esbuild-kit/tsx": 5686,
+		"privatenumber/tsx": 5686,
 		"privatenumber/esbuild-loader": 3449,
 		"privatenumber/tasuku": 1774,
 		"privatenumber/minification-benchmarks": 1138,

--- a/src/data/npm-downloads.json
+++ b/src/data/npm-downloads.json
@@ -1884,7 +1884,7 @@
 		},
 		{
 			"name": "tsx",
-			"repository": "https://github.com/esbuild-kit/tsx",
+			"repository": "https://github.com/privatenumber/tsx",
 			"description": "TypeScript Execute (tsx): Node.js enhanced with esbuild to run TypeScript & ESM files",
 			"lastPublishDate": "2023-10-17T21:59:05.132Z",
 			"latestVersion": "3.14.0",


### PR DESCRIPTION
`esbuild-kit/tsx` has been moved to `privatenumber/tsx`

- https://github.com/privatenumber/tsx/discussions/316#discussioncomment-7519937
- https://github.com/esbuild-kit/esno/pull/39